### PR TITLE
Potential fix for code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/pkg/controller/sparkapplication/sparkui.go
+++ b/pkg/controller/sparkapplication/sparkui.go
@@ -70,10 +70,10 @@ func getUITargetPort(app *v1beta2.SparkApplication) (int32, error) {
 	if ok {
 		port, err := strconv.Atoi(portStr)
 		if err != nil {
-			return defaultSparkWebUIPort, err
+			return defaultSparkWebUIPort, nil
 		}
 		if port < math.MinInt32 || port > math.MaxInt32 {
-			return defaultSparkWebUIPort, fmt.Errorf("Spark UI port %d out of int32 bounds", port)
+			return defaultSparkWebUIPort, nil
 		}
 		return int32(port), nil
 	}

--- a/pkg/controller/sparkapplication/sparkui.go
+++ b/pkg/controller/sparkapplication/sparkui.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"math"
 
 	clientset "k8s.io/client-go/kubernetes"
 
@@ -68,7 +69,13 @@ func getUITargetPort(app *v1beta2.SparkApplication) (int32, error) {
 	portStr, ok := app.Spec.SparkConf[sparkUIPortConfigurationKey]
 	if ok {
 		port, err := strconv.Atoi(portStr)
-		return int32(port), err
+		if err != nil {
+			return defaultSparkWebUIPort, err
+		}
+		if port < math.MinInt32 || port > math.MaxInt32 {
+			return defaultSparkWebUIPort, fmt.Errorf("Spark UI port %d out of int32 bounds", port)
+		}
+		return int32(port), nil
 	}
 	return defaultSparkWebUIPort, nil
 }

--- a/pkg/controller/sparkapplication/sparkui.go
+++ b/pkg/controller/sparkapplication/sparkui.go
@@ -70,10 +70,10 @@ func getUITargetPort(app *v1beta2.SparkApplication) (int32, error) {
 	if ok {
 		port, err := strconv.Atoi(portStr)
 		if err != nil {
-			return defaultSparkWebUIPort, nil
+			return defaultSparkWebUIPort, err
 		}
 		if port < math.MinInt32 || port > math.MaxInt32 {
-			return defaultSparkWebUIPort, nil
+			return defaultSparkWebUIPort, fmt.Errorf("Spark UI port %d out of int32 bounds", port)
 		}
 		return int32(port), nil
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/relativityone/spark-on-k8s-operator/security/code-scanning/1](https://github.com/relativityone/spark-on-k8s-operator/security/code-scanning/1)

The best way to fix this problem is to ensure the input is validated before converting from architecture-dependent `int` to a fixed-size `int32`. Since the code is using `strconv.Atoi`, which always parses to the system's native `int`, directly converting this to `int32` without bound checks may result in incorrect values if the input is outside the range of a valid `int32`. 
To fix:
- After parsing the string to `int`, check that the value is within the valid bounds for `int32` (i.e., between `math.MinInt32` and `math.MaxInt32`).
- If the value is out of bounds, return an error or a default value.
- This requires importing the `math` package for `math.MinInt32` and `math.MaxInt32`.
- Make this change in the `getUITargetPort` function in pkg/controller/sparkapplication/sparkui.go at and around line 71.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
